### PR TITLE
Add headers to RouteResponseCallback

### DIFF
--- a/src/helper/handle-request/clone-request-headers.ts
+++ b/src/helper/handle-request/clone-request-headers.ts
@@ -1,0 +1,16 @@
+import { Request } from '../../models/request.js';
+
+export const cloneRequestHeaders = (req: Request) => {
+  const headers: { [key: string]: string | string[] } = {};
+  
+  for (const key in req.headers) {
+    const value = req.headers[key];
+    if (value instanceof Array) {
+      headers[key] = [...(value as string[])];
+    } else {
+      headers[key] = value;
+    }
+  }
+
+  return headers;
+};

--- a/src/helper/handle-request/clone-request-headers.ts
+++ b/src/helper/handle-request/clone-request-headers.ts
@@ -2,11 +2,11 @@ import { Request } from '../../models/request.js';
 
 export const cloneRequestHeaders = (req: Request) => {
   const headers: { [key: string]: string | string[] } = {};
-  
+
   for (const key in req.headers) {
     const value = req.headers[key];
     if (value instanceof Array) {
-      headers[key] = [...(value as string[])];
+      headers[key] = [...value];
     } else {
       headers[key] = value;
     }

--- a/src/helper/handle-request/try-get-response-for-request.ts
+++ b/src/helper/handle-request/try-get-response-for-request.ts
@@ -1,6 +1,7 @@
 import { Config } from '../../models/config.js';
 import { Request } from '../../models/request.js';
 import { RouteParams } from '../../models/route-params.js';
+import { cloneRequestHeaders } from './clone-request-headers.js';
 import { failBecauseOfNotOrWrongMockedRoute } from './fail-because-of-not-or-wrong-mocked-route.js';
 import { getAllMatchingStubsAndTheirSpecificity } from './get-all-matching-stubs-and-their-specificity.js';
 import { logErrorAndReplyWithErrorCode } from './log-error-and-reply-with-error-code.js';
@@ -39,10 +40,11 @@ export const tryGetResponseForRequest = async (req: Request, config: Config): Pr
     return { closed: true };
   }
   const parsedBody = parseRequestBody(req);
+  const headers = cloneRequestHeaders(req);
 
   let response: any;
   try {
-    response = await stub.response({ body: parsedBody, params: paramMap });
+    response = await stub.response({ body: parsedBody, params: paramMap, headers });
   } catch (e: any) {
     logErrorAndReplyWithErrorCode(stub, req, e, config);
     return { closed: true };

--- a/src/models/route-response-callback.ts
+++ b/src/models/route-response-callback.ts
@@ -3,4 +3,5 @@ import { ExtractRouteParams } from './extract-route-params.js';
 export type RouteResponseCallback<T extends string, Body> = (request: {
   body: Body;
   params: ExtractRouteParams<T>;
+  headers: { [key: string]: string | string[] };
 }) => any | Promise<any>;

--- a/test/tests/headers.spec.ts
+++ b/test/tests/headers.spec.ts
@@ -1,0 +1,26 @@
+import { FakeNetworkIntercept } from "../fake-network-intercept.js";
+import { afterEachLog } from "../log.js";
+import { parseFetch } from "../parse-fetch.js";
+import { TestEasyNetworkStub } from "../test-easy-network-stub.js";
+
+describe('Headers', () => {
+    let fakeNetwork: FakeNetworkIntercept;
+    let testEasyNetworkStub: TestEasyNetworkStub;
+    beforeEach(async () => {
+      fakeNetwork = new FakeNetworkIntercept();
+      testEasyNetworkStub = new TestEasyNetworkStub(/MyServer\/api\/Blog/);
+      await testEasyNetworkStub.init(fakeNetwork);
+    });
+    afterEach(async () => {
+      await afterEachLog(testEasyNetworkStub);
+    });
+
+    test("All Headers are copied to the RouteResponseCallback", async () => {
+        testEasyNetworkStub.stub('GET', 'posts/all', ({ headers }) => {
+            return headers;
+        });
+        const headers = { "content-type": "application/json", "X-Custom-Header": [ "Entry1", "Entry2", "Entry3" ] };
+        const response = await parseFetch(fakeNetwork, { method: 'GET', url: 'MyServer/api/Blog/posts/all', headers });
+        expect(response).toEqual(headers);
+    });
+});


### PR DESCRIPTION
Added request headers to RouteResponseCallback, so that they can be asserted in the stub during testing.